### PR TITLE
Fix for cl-lib.el

### DIFF
--- a/helm-c-moccur.el
+++ b/helm-c-moccur.el
@@ -91,6 +91,9 @@
 
 ;;;code:
 
+(eval-when-compile
+  (require 'cl))
+
 (require 'helm)
 (require 'cl-lib)
 (require 'color-moccur)
@@ -212,7 +215,7 @@ nilなら使用しない"
         (when (save-excursion
                 (beginning-of-line)
                 (looking-at re))
-          (case direction
+          (cl-case direction
             (next (helm-next-line))
             (previous (helm-previous-line)))))
       (helm-mark-current-line))))
@@ -243,8 +246,8 @@ nilなら使用しない"
     (save-selected-window
       (select-window (get-buffer-window helm-buffer 'visible))
 
-      (case unit
-        (file (let ((search-fn (case direction
+      (cl-case unit
+        (file (let ((search-fn (cl-case direction
                                  (next 're-search-forward)
                                  (previous (prog1 're-search-backward
                                              (re-search-backward helm-c-moccur-info-line-re nil t)))
@@ -516,12 +519,12 @@ nilなら使用しない"
 
 (defun helm-c-moccur-dmoccur-higligt-info-line ()
   (let ((re helm-c-moccur-info-line-re))
-    (loop initially (goto-char (point-min))
-          while (re-search-forward re nil t)
-          do (put-text-property (line-beginning-position)
-                                (line-end-position)
-                                'face
-                                'helm-header))))
+    (cl-loop initially (goto-char (point-min))
+             while (re-search-forward re nil t)
+             do (put-text-property (line-beginning-position)
+                                   (line-end-position)
+                                   'face
+                                   'helm-header))))
 
 (defun helm-c-moccur-dmoccur-scraper ()
   (when (buffer-live-p moccur-mocur-buffer)
@@ -533,10 +536,10 @@ nilなら使用しない"
         (when helm-c-moccur-higligt-info-line-flag
           (helm-c-moccur-dmoccur-higligt-info-line))
         
-        (loop initially (progn (goto-char (point-min))
-                               (forward-line 1))
-              while (re-search-forward re nil t)
-              do (push (match-string 0) lines))
+        (cl-loop initially (progn (goto-char (point-min))
+                                  (forward-line 1))
+                 while (re-search-forward re nil t)
+                 do (push (match-string 0) lines))
         (nreverse lines)))))
 
 (defun helm-c-moccur-dmoccur-get-candidates ()
@@ -650,10 +653,10 @@ nilなら使用しない"
 
 (defun helm-c-moccur-last-sources-is-moccur-p ()
   (and (equal helm-c-moccur-last-buffer (current-buffer))
-       (every (lambda (source)
-                (let ((source (if (listp source) source (symbol-value source))))
-                  (string-match "moccur" (assoc-default 'name source))))
-              helm-last-sources)))
+       (cl-every (lambda (source)
+                   (let ((source (if (listp source) source (symbol-value source))))
+                     (string-match "moccur" (assoc-default 'name source))))
+                 helm-last-sources)))
 
 (defun helm-c-moccur-resume ()
   (interactive)


### PR DESCRIPTION
- Use cl-lib functions/macros instead of cl.el
- Load cl.el at compile time for using lexical-let
